### PR TITLE
Converts button styles and from next/link to radixui themes link

### DIFF
--- a/app/components/CTAButton.tsx
+++ b/app/components/CTAButton.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@radix-ui/themes";
-import Link from "next/link";
+import { Button, Link } from "@radix-ui/themes";
 import React from "react";
 
 type CTAButtonProps =
@@ -8,7 +7,7 @@ type CTAButtonProps =
 
 const CTAButton: React.FC<CTAButtonProps> = ({ href, text, Icon }) => {
   return (
-    <Link href={href}>
+    <Link href={href} asChild>
       <Button className="m-2" type="button">
         {Icon ? Icon && <>{Icon}</> : text}
       </Button>

--- a/app/components/CTAButton.tsx
+++ b/app/components/CTAButton.tsx
@@ -8,7 +8,7 @@ type CTAButtonProps =
 const CTAButton: React.FC<CTAButtonProps> = ({ href, text, Icon }) => {
   return (
     <Link href={href} asChild>
-      <Button className="m-2" type="button">
+      <Button className="my-4 p-4 py-5" variant="outline" type="button">
         {Icon ? Icon && <>{Icon}</> : text}
       </Button>
     </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         <body>
           <Theme
             appearance="dark"
-            accentColor="green"
+            accentColor="grass"
             radius="small"
             className="flex flex-col h-screen w-screen"
             panelBackground="translucent"


### PR DESCRIPTION
- Converts the usage of `next/link` to `@radix-ui/themes` link for improved accessibility. 
  - Unfortunately this might lead to a loss of very important next/link feature of eagerly loading linked routes. Therefore this is a temporary solution until I conver the buttons to use ShaduiCN.
- The `asChild` link type is used to ensure that the Link with a Button child acts as a single tab index. 

- Padding, variant style, and margin are updated on the CTAButton component.

- Notably, the theme color is changed from green to grass.