### PR TITLE
Responsive height on mobile browsers, tailwind color vars using radix theme

### DIFF
--- a/app/components/AnimatedIconStack.tsx
+++ b/app/components/AnimatedIconStack.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { GlobeIcon } from "@radix-ui/react-icons";
-import { Box } from "@radix-ui/themes";
+import { Box, Button, Flex } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
 import React, { useState } from "react";
 import IconList, { HyperMediaIconProps } from "./IconsList";
@@ -31,53 +31,50 @@ const AnimatedIconStack: React.FC<AnimatedIconStackProps> = ({
 
   return (
     <Box className={buttonClassName}>
-      {Icon ? (
-        <Box
-          className="hover:scale-125 transition duration-200 ease-in-out opacity-70 active:scale-75"
+      <Flex className="hover:scale-125 transition duration-200 ease-in-out opacity-70 active:scale-90">
+        <Button
           onClick={toggleIconsVisibility}
+          mx="1"
+          type="button"
+          variant="ghost"
         >
-          <Icon />
-        </Box>
-      ) : (
-        <GlobeIcon
-          onClick={toggleIconsVisibility}
-          className="hover:scale-125 transition duration-200 ease-in-out opacity-70 active:scale-75"
-          width="1rem"
-          height="1rem"
-        />
-      )}
+          {Icon ? <Icon /> : <GlobeIcon onClick={toggleIconsVisibility} />}
+        </Button>
+      </Flex>
       <AnimatePresence>
         {iconsVisible && (
-          <motion.div
-            initial={{
-              x: isLeft ? "-10%" : "10%",
-              y: isUp ? "50%" : "-50%",
-              opacity: 0,
-              rotateZ: isLeft ? "10deg" : "-10deg",
-              scaleY: 0,
-            }}
-            animate={{
-              x: "0",
-              y: "0%",
-              opacity: 1,
-              rotateZ: "0deg",
-              scaleY: 1,
-            }}
-            exit={{
-              x: isLeft ? "-10%" : "10%",
-              y: isUp ? "50%" : "-50%",
-              opacity: 0,
-              rotateZ: isLeft ? "10deg" : "-10deg",
-              scaleY: 0,
-            }}
-            transition={{ duration: 0.3 }}
-            className={`${popoverClassName} p-3 absolute rounded bg-black bg-opacity-10 border border-white border-opacity-20`}
-          >
-            <IconList
-              className="flex justify-end place-self-end flex-col "
-              icons={iconList}
-            />
-          </motion.div>
+          <Box>
+            <motion.div
+              initial={{
+                x: isLeft ? "-10%" : "10%",
+                y: isUp ? "50%" : "-50%",
+                opacity: 0,
+                rotateZ: isLeft ? "10deg" : "-10deg",
+                scaleY: 0,
+              }}
+              animate={{
+                x: "0",
+                y: "0%",
+                opacity: 1,
+                rotateZ: "0deg",
+                scaleY: 1,
+              }}
+              exit={{
+                x: isLeft ? "-10%" : "10%",
+                y: isUp ? "50%" : "-50%",
+                opacity: 0,
+                rotateZ: isLeft ? "10deg" : "-10deg",
+                scaleY: 0,
+              }}
+              transition={{ duration: 0.3 }}
+              className={`${popoverClassName} p-3 absolute rounded bg-black bg-opacity-10 border border-white border-opacity-20`}
+            >
+              <IconList
+                className="flex justify-end place-self-end flex-col "
+                icons={iconList}
+              />
+            </motion.div>
+          </Box>
         )}
       </AnimatePresence>
     </Box>

--- a/app/components/AnimatedIconStack.tsx
+++ b/app/components/AnimatedIconStack.tsx
@@ -11,7 +11,7 @@ type AnimatedIconStackProps = {
   iconList: HyperMediaIconProps[];
   directionX: "left" | "right";
   directionY: "up" | "down";
-  background: "solid" | "translucent";
+  background?: "solid" | "translucent";
   Icon?: React.FC;
 };
 

--- a/app/components/AnimatedIconStack.tsx
+++ b/app/components/AnimatedIconStack.tsx
@@ -11,6 +11,7 @@ type AnimatedIconStackProps = {
   iconList: HyperMediaIconProps[];
   directionX: "left" | "right";
   directionY: "up" | "down";
+  background: "solid" | "translucent";
   Icon?: React.FC;
 };
 
@@ -19,6 +20,7 @@ const AnimatedIconStack: React.FC<AnimatedIconStackProps> = ({
   popoverClassName,
   directionX = "left",
   directionY = "up",
+  background = "translucent",
   iconList,
   Icon,
 }: AnimatedIconStackProps) => {
@@ -66,8 +68,15 @@ const AnimatedIconStack: React.FC<AnimatedIconStackProps> = ({
                 rotateZ: isLeft ? "10deg" : "-10deg",
                 scaleY: 0,
               }}
+              style={{
+                background:
+                  background === "translucent"
+                    ? "var(--color-panel-translucent)"
+                    : "var(--color-panel-solid)",
+                backdropFilter: "blur(10px)",
+              }}
               transition={{ duration: 0.3 }}
-              className={`${popoverClassName} p-3 absolute rounded bg-black bg-opacity-10 border border-white border-opacity-20`}
+              className={`${popoverClassName}  p-3 absolute rounded border border-white border-opacity-20`}
             >
               <IconList
                 className="flex justify-end place-self-end flex-col "

--- a/app/components/FootPanel.tsx
+++ b/app/components/FootPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { DotFilledIcon } from "@radix-ui/react-icons";
-import { Box, Grid, Link } from "@radix-ui/themes";
+import { Box, Flex, Grid, Link } from "@radix-ui/themes";
 import React, { useEffect, useState } from "react";
 import { POLLING_INTERVAL } from "../lib/constants";
 import AnimatedIconStack from "./AnimatedIconStack";
@@ -35,9 +35,11 @@ const FootPanel: React.FC<FootPanelProps> = ({
   return (
     <Box className={className}>
       <Grid width="100%" columns="3">
-        <Link href="/contact" asChild>
-          <DotFilledIcon color="green" width="1.25rem" height="1.25rem" />
-        </Link>
+        <Flex align="center">
+          <Link href="/contact" asChild>
+            <DotFilledIcon width="1.15rem" height="1.15rem" />
+          </Link>
+        </Flex>
         <p className="flex text-nowrap justify-center opacity-60 text-sm">
           Johannesburg {currentTime}
         </p>
@@ -45,13 +47,15 @@ const FootPanel: React.FC<FootPanelProps> = ({
           className="sm:flex justify-end hidden sm:visible place-self-end"
           icons={socialIcons}
         />
-        <AnimatedIconStack
-          iconList={socialIcons}
-          directionX="right"
-          directionY="up"
-          buttonClassName="flex justify-end sm:hidden place-self-end"
-          popoverClassName="bottom-11 right-1 mb-1"
-        />
+        <Flex justify="end" align="center">
+          <AnimatedIconStack
+            iconList={socialIcons}
+            directionX="right"
+            directionY="up"
+            buttonClassName="flex justify-end sm:hidden"
+            popoverClassName="bottom-12 right-1.5 mb-1"
+          />
+        </Flex>
       </Grid>
     </Box>
   );

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -22,14 +22,14 @@ const Header: React.FC<HeaderProps> = ({ className }: HeaderProps) => {
           <StylizedTextLogo />
         </Flex>
         <Flex justify="end" align="center">
-          <WindowControls className="opacity-50 hidden sm:block" gap="4" />
+          <WindowControls className="opacity-50 hidden sm:flex" gap="4" />
           <AnimatedIconStack
             directionX="left"
             directionY="down"
             Icon={HamburgerMenuIcon}
             iconList={navIcons}
             buttonClassName="flex place-self-center sm:hidden"
-            popoverClassName="top-12 right-1 mt-1 z-10"
+            popoverClassName="top-12 right-1.5 mt-2 z-10"
           />
         </Flex>
       </Grid>

--- a/app/components/layout/Main/layout.tsx
+++ b/app/components/layout/Main/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { OrbColorOnPageType, OrbColorOnPagesConfig } from "@/app/lib/constants";
-import { Box, ScrollArea, Theme } from "@radix-ui/themes";
+import { Box, Flex, ScrollArea, Theme } from "@radix-ui/themes";
 import { usePathname } from "next/navigation";
 import React, { useEffect, useRef, useState } from "react";
 import FootPanel from "../../FootPanel";
@@ -27,7 +27,7 @@ const MainLayout: React.FC<{
 
   return (
     <Theme accentColor={orbColor.radixColor} className="w-full h-full">
-      <Box className="flex flex-col flex-grow w-full h-full border rounded-md border-white border-opacity-20 backdrop-blur-3xl bg-gradient-to-br shadow-inner shadow-slate-700">
+      <Flex className="flex flex-col flex-grow w-full h-full border rounded-md border-white border-opacity-20 backdrop-blur-3xl bg-gradient-to-br shadow-inner shadow-slate-700">
         <Header className="h-auto py-2 px-4 flex place-content-center border-b border-opacity-10 border-white" />
 
         <main className="flex flex-grow flex-row overflow-hidden">
@@ -49,7 +49,7 @@ const MainLayout: React.FC<{
         <footer>
           <FootPanel className="h-auto py-3 px-4 flex place-content-center border-t border-white border-opacity-10 sticky bottom-0 " />
         </footer>
-      </Box>
+      </Flex>
     </Theme>
   );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
         lang="en"
         className={`${SpaceMono.variable} ${FixedSys.variable} ${ChakraPetch.variable}`}
       >
-        <body className="flex flex-col h-screen w-screen overflow-hidden">
+        <body className="flex flex-col h-dvh w-dvh overflow-hidden">
           <Theme
             appearance="dark"
             accentColor="grass"

--- a/app/lib/colors.ts
+++ b/app/lib/colors.ts
@@ -1,6 +1,17 @@
-export const PrimaryColor = "#42984d";
-
-export const PrimaryRadixColor = "grass";
+export const AccentPrimaryColors = {
+  1: "var(--accent-1)",
+  2: "var(--accent-2)",
+  3: "var(--accent-3)",
+  4: "var(--accent-4)",
+  5: "var(--accent-5)",
+  6: "var(--accent-6)",
+  7: "var(--accent-7)",
+  8: "var(--accent-8)",
+  9: "var(--accent-9)",
+  10: "var(--accent-10)",
+  11: "var(--accent-11)",
+  12: "var(--accent-12)",
+};
 
 export const LightPrimaryColors = {
   1: "#ECF0EC",
@@ -66,6 +77,12 @@ export const DarkGrayColors = {
 
 export const DarkBackgroundColor = "#1A211E";
 
+// Above this line is cosmetic, below is functional
+
+export const AccentColors = {
+  accent: AccentPrimaryColors,
+};
+
 export const DarkModeColors = {
   primary: DarkPrimaryColors,
   gray: DarkGrayColors,
@@ -76,6 +93,31 @@ export const LightModeColors = {
   primary: LightPrimaryColors,
   gray: LightGrayColors,
   background: LightBackgroundColor,
+};
+
+export const AccentTailwindColors = {
+  bg: {
+    1: AccentColors.accent[1],
+    2: AccentColors.accent[1],
+  },
+  interactive: {
+    1: AccentColors.accent[3],
+    2: AccentColors.accent[4],
+    3: AccentColors.accent[5],
+  },
+  border: {
+    1: AccentColors.accent[6],
+    2: AccentColors.accent[7],
+    3: AccentColors.accent[8],
+  },
+  solid: {
+    1: AccentColors.accent[9],
+    2: AccentColors.accent[10],
+  },
+  text: {
+    1: AccentColors.accent[11],
+    2: AccentColors.accent[12],
+  },
 };
 
 export const DarkModeTailwindColors = {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import {
+  AccentTailwindColors,
   DarkGrayTailwindColors,
   DarkModeTailwindColors,
 } from "./app/lib/colors";
@@ -29,6 +30,13 @@ const config: Config = {
           border: { ...DarkGrayTailwindColors.border },
           solid: { ...DarkGrayTailwindColors.solid },
           text: { ...DarkGrayTailwindColors.text },
+        },
+        accent: {
+          bg: { ...AccentTailwindColors.bg },
+          interactive: { ...AccentTailwindColors.interactive },
+          border: { ...AccentTailwindColors.border },
+          solid: { ...AccentTailwindColors.solid },
+          text: { ...AccentTailwindColors.text },
         },
       },
     },


### PR DESCRIPTION
Adjusts the body element in the RootLayout component to use dynamic viewport heights (`h-dvh` and `w-dvh`) instead of fixed screen heights (`h-screen` and `w-screen`). This ensures that the body element adjusts properly to different screen sizes and improves the responsiveness of the application.

Adds accent colors and background option to AnimatedIconStack component