### PR TITLE
Add radix base colors to tailwind config

### DIFF
--- a/app/lib/colors.ts
+++ b/app/lib/colors.ts
@@ -1,3 +1,32 @@
+export const RadixBaseColorValues = {
+  gray: "var(--gray-9)",
+  gold: "var(--gold-9)",
+  bronze: "var(--bronze-9)",
+  brown: "var(--brown-9)",
+  yellow: "var(--yellow-9)",
+  amber: "var(--amber-9)",
+  orange: "var(--orange-9)",
+  tomato: "var(--tomato-9)",
+  red: "var(--red-9)",
+  ruby: "var(--ruby-9)",
+  crimson: "var(--crimson-9)",
+  pink: "var(--pink-9)",
+  plum: "var(--plum-9)",
+  purple: "var(--purple-9)",
+  violet: "var(--violet-9)",
+  iris: "var(--iris-9)",
+  indigo: "var(--indigo-9)",
+  blue: "var(--blue-9)",
+  cyan: "var(--cyan-9)",
+  teal: "var(--teal-9)",
+  jade: "var(--jade-9)",
+  green: "var(--green-9)",
+  grass: "var(--grass-9)",
+  lime: "var(--lime-9)",
+  mint: "var(--mint-9)",
+  sky: "var(--sky-9)",
+};
+
 export const ShadowShadeValues = {
   1: "var(--shadow-1)",
   2: "var(--shadow-2)",
@@ -88,6 +117,10 @@ export const DarkBackgroundColor = "#1A211E";
 
 // Above this line is cosmetic, below is functional
 
+export const RadixBaseColors = {
+  color: RadixBaseColorValues,
+};
+
 export const ShadowShades = {
   shadow: ShadowShadeValues,
 };
@@ -107,6 +140,8 @@ export const LightModeColors = {
   gray: LightGrayColors,
   background: LightBackgroundColor,
 };
+
+export const RadixBaseColorTailwindUtils = { ...RadixBaseColors.color };
 
 export const ShadowShadeTailwindUtils = {
   "theme-inset": ShadowShadeValues[1],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@ import {
   AccentTailwindUtils,
   DarkGrayTailwindUtils,
   DarkModeTailwindUtils,
+  RadixBaseColorTailwindUtils,
   ShadowShadeTailwindUtils,
 } from "./app/lib/colors";
 import themeConfig from "./tailwind.theme.config";
@@ -38,6 +39,11 @@ const config: Config = {
           border: { ...AccentTailwindUtils.border },
           solid: { ...AccentTailwindUtils.solid },
           text: { ...AccentTailwindUtils.text },
+        },
+        radix: {
+          base: {
+            ...RadixBaseColorTailwindUtils,
+          },
         },
       },
       boxShadow: {


### PR DESCRIPTION
Adds radix base colors to the tailwind config. Radix base colors are defined in the `RadixBaseColorValues` object and are used to set the color values for various elements in the application. The `RadixBaseColors` object is then used to apply these colors in the tailwind utility classes. This addition enhances the customization options for the application's color scheme.