### PR TITLE
Add WP_DOMAIN secret to deploy-to-cpanel workflow

### DIFF
--- a/.github/workflows/deploy-to-cpanel.yml
+++ b/.github/workflows/deploy-to-cpanel.yml
@@ -33,6 +33,7 @@ jobs:
       NODE_DIR: ${{ secrets.NODE_DIR }};
       ALLOWED_ORIGIN: ${{ secrets.ALLOWED_ORIGIN }}
       RESTART_FILE_PATH: ${{ secrets.RESTART_FILE_PATH }}
+      WP_DOMAIN: ${{ secrets.WP_DOMAIN }}
 
     steps:
       - name: Clone repository

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ export default {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: process.env.WP_DOMAIN,
+        hostname: `${process.env.WP_DOMAIN}`,
         pathname: "/wp-content/uploads/**",
       },
     ],


### PR DESCRIPTION
Adds the WP_DOMAIN secret to the deploy-to-cpanel workflow. The WP_DOMAIN secret is used in the remotePatterns configuration to specify hostnames for images. This allows the application to access the domain as an image source.