### PR TITLE
docs: portfolio completeness/polish improvement notes

### DIFF
--- a/docs/improvement-notes/01-readme-completeness.md
+++ b/docs/improvement-notes/01-readme-completeness.md
@@ -1,0 +1,15 @@
+# README completeness
+
+## Current state
+`README.md` is two lines: the site title and a link to the live deployment. There is no description of the tech stack, no setup/dev instructions, no scripts reference, and no screenshots.
+
+## Why it matters
+This repo is itself a portfolio artifact — anyone who clicks through from the live site to the GitHub repo (recruiters, other developers, collaborators) lands on a near-empty README. For a project meant to demonstrate craft, the README is one of the first things a technical reviewer reads, and right now it undersells everything the codebase actually does (custom Next.js 15 app with an Express/PM2 server, Framer Motion + GSAP animation layer, WordPress-backed blog, Resend-powered contact form, a "desktop OS" themed UI with window cards).
+
+## Suggested action
+Expand the README with:
+- A short project description and feature list (blog, projects, experience timeline, contact form, "desktop" UI theme)
+- Tech stack table (Next.js 15, custom Express/PM2 server, Tailwind, Radix UI, Framer Motion/GSAP, Resend, WordPress as a headless content source)
+- Local dev setup: `npm install`, `npm run dev` (note the `--experimental-https` flag and what it's for), required `.env` vars (see the companion note on `.env.example`)
+- Available scripts (`dev`, `build`, `start`, `lint`, `verify`) and what each does
+- 1-2 screenshots or a short GIF of the live site

--- a/docs/improvement-notes/02-seo-and-discovery-metadata.md
+++ b/docs/improvement-notes/02-seo-and-discovery-metadata.md
@@ -1,0 +1,13 @@
+# SEO / discovery metadata gaps
+
+## Current state
+`app/layout.tsx` only sets `title` and `description` in the root `Metadata` export. There is no `robots.txt` or `sitemap.xml` in `public/`, no Open Graph or Twitter card metadata (`openGraph`, `twitter` fields on the `Metadata` object), and no `manifest.json` for PWA/installability.
+
+## Why it matters
+This is a portfolio site whose entire purpose is to be found and shared — by recruiters via search, and by links dropped in Slack/LinkedIn/Twitter. Without Open Graph tags, a shared link renders as a bare URL with no preview image or description in any chat app or social platform. Without a sitemap, search engines have to rely purely on crawling the site's internal links to discover the blog posts and project pages under `app/blog`, `app/projects/[slug]`, `app/experiences/[slug]`.
+
+## Suggested action
+- Add `openGraph` and `twitter` fields to the root metadata (and per-page `generateMetadata` for blog/project detail pages, using each post/project's own title/description/cover image)
+- Add a static or dynamically generated `sitemap.xml` (Next.js 15 supports a `sitemap.ts` route convention) covering blog posts and project slugs
+- Add `robots.txt` (Next.js supports a `robots.ts` convention too)
+- Consider a `public/manifest.json` for basic PWA metadata (theme color, icons) given there's already a `favicon.svg`

--- a/docs/improvement-notes/03-ci-gate-missing-on-branches.md
+++ b/docs/improvement-notes/03-ci-gate-missing-on-branches.md
@@ -1,0 +1,15 @@
+# No CI gate on branches/PRs
+
+## Current state
+The only workflow, `.github/workflows/deploy-to-cpanel.yml`, triggers on `push` to `main` and `stg` and goes straight to a build-and-deploy job. There is no workflow that runs on pull requests or feature branches, and the repo already has `lint` and `verify` (`tsc --noEmit && next lint`) scripts defined in `package.json` that currently aren't wired into CI at all.
+
+## Why it matters
+Right now, the first time a broken build, type error, or lint failure would be caught automatically is during the deploy to `main`/`stg` itself — there's no earlier, cheaper checkpoint on a feature branch or PR. Given the repo already has branches like `bugfix/BrokenDeploymentPipeline`, catching regressions before they reach a deploy-triggering branch would save the deploy-and-discover cycle.
+
+## Suggested action
+Add a lightweight `.github/workflows/ci.yml` that runs on `pull_request` (and optionally `push` to non-deploy branches):
+- `npm ci`
+- `npm run verify` (already exists — just needs to be invoked)
+- `npm run build`
+
+This is a small, additive change (doesn't touch the existing deploy workflow) and gives a pass/fail signal on every branch before it's merged toward `main`/`stg`.

--- a/docs/improvement-notes/04-no-automated-tests.md
+++ b/docs/improvement-notes/04-no-automated-tests.md
@@ -1,0 +1,14 @@
+# No automated test coverage
+
+## Current state
+`package.json` has no test script and no testing framework in `dependencies`/`devDependencies` (no Jest, Vitest, Playwright, Testing Library, etc.). There's meaningful interactive surface area that could silently break: the contact form (`ElegantContactForm.tsx` → `app/api/contact` → Resend email), the WordPress-backed blog/project data fetching (`app/lib/wordpress-types.ts`, `server-lib.ts`), and dynamic routes (`app/blog/posts`, `app/experiences/[slug]`, `app/projects/[slug]`).
+
+## Why it matters
+For a personal portfolio, full unit-test coverage is overkill and not worth the time investment. But the contact form is the one piece of functional (not just visual) behavior on the site — if it silently breaks (a Resend API change, an env var typo, a schema mismatch with the WordPress source), the site keeps looking fine while quietly failing at its one real job: letting someone reach out.
+
+## Suggested action
+Skip broad unit testing. Add a small number of targeted checks instead:
+- One Playwright (or even a simple script hitting the API route) end-to-end test for the contact form happy path
+- One smoke test that hits each dynamic route type (a blog post, a project, an experience) and asserts a 200 response, to catch WordPress data-shape regressions early
+
+This is a much smaller lift than full coverage and directly protects the one interactive feature that has real consequences if broken.

--- a/docs/improvement-notes/05-accessibility-audit-gap.md
+++ b/docs/improvement-notes/05-accessibility-audit-gap.md
@@ -1,0 +1,11 @@
+# No automated accessibility auditing
+
+## Current state
+The project depends on `@radix-ui/react-accessible-icon` and Radix UI primitives generally (which are a11y-conscious by design), but there's no automated accessibility check anywhere in the toolchain — no `eslint-plugin-jsx-a11y` in the ESLint config, no axe-core/Lighthouse CI step. Meanwhile the UI leans heavily on custom, non-standard interactive/visual components: `MatrixRain`, `ScanLineEffect`, `MouseGlowEffect`, parallax scroll transitions (`useScrollDelegation`, `useScrollTransition`), and a "desktop window" metaphor (`WindowCard`, `PortfolioPageWrapper`).
+
+## Why it matters
+Heavy custom animation/visual-effect components are exactly the pattern most likely to introduce accessibility regressions unnoticed — e.g. motion that doesn't respect `prefers-reduced-motion`, custom "window" interactions that aren't keyboard-navigable, or decorative canvas/effect layers that aren't marked `aria-hidden`. None of this fails a build today because nothing is checking for it.
+
+## Suggested action
+- Add `eslint-plugin-jsx-a11y` to the existing `next lint` config — this is a near-zero-cost addition since ESLint already runs in `verify`
+- Do a manual pass (or add `@axe-core/playwright` alongside the E2E tests from the testing note) specifically on the animation-heavy components to confirm `prefers-reduced-motion` is respected and that decorative effects are hidden from assistive tech

--- a/docs/improvement-notes/06-missing-env-example.md
+++ b/docs/improvement-notes/06-missing-env-example.md
@@ -1,0 +1,10 @@
+# No `.env.example` for onboarding
+
+## Current state
+The repo has `.env`, `.env.local`, `.env.development`, and `.env.production` locally (all correctly git-ignored), but there is no committed `.env.example` documenting which variables exist or what they're for. From the deploy workflow, at least these are required somewhere in the stack: `NODE_DIR`, `ALLOWED_ORIGIN`, `RESTART_FILE_PATH`, `WP_DOMAIN`, `RESEND_API_KEY`, `PUBLIC_RESUME_URL`.
+
+## Why it matters
+If this repo is ever shown to another developer as a code sample, or if a future version of the setup needs to be reproduced on a new machine, there's currently no way to know which environment variables are required without spelunking through the deploy workflow secrets list and grepping the codebase for `process.env`. This is exactly the kind of thing that's trivial to document now and painful to reconstruct later.
+
+## Suggested action
+Add a committed `.env.example` with each required variable name and a one-line comment on its purpose (no real values) — e.g. `WP_DOMAIN` (WordPress content source), `RESEND_API_KEY` (contact form email delivery), `PUBLIC_RESUME_URL` (resume download link), etc. Reference it from the README setup section (see the README completeness note).


### PR DESCRIPTION
## Summary
Six grounded improvement/research notes on the portfolio's completeness and polish, based on the actual repo structure and content (not generic boilerplate):

1. README completeness (currently 2 lines)
2. SEO/discovery metadata (no OG tags, sitemap, robots.txt, manifest)
3. CI gate missing on PRs (only deploy-on-push exists; lint/verify scripts aren't wired to any PR check)
4. No automated tests (suggests targeted E2E on the contact form + dynamic routes, not full coverage)
5. Accessibility audit gap (custom animation components like MatrixRain/ScanLineEffect/parallax are unaudited)
6. Missing `.env.example` despite 6+ env vars used in the deploy workflow

## Test plan
- [x] No existing files modified, only new files added under `docs/improvement-notes/`
- [x] `package-lock.json`'s pre-existing unstaged change left untouched