### PR TITLE
docs: add .env.example for onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,67 +1,62 @@
-# Copy this file to .env / .env.local / .env.development / .env.production
-# (as appropriate) and fill in real values. Never commit the filled-in files.
+# Environment variables used by this app.
+# Copy this file to .env (and/or .env.local, .env.development, .env.production
+# as appropriate) and fill in real values. Never commit the filled-in files -
+# .gitignore blanket-ignores .env.* (with an explicit exception for this file).
 
-# --- Server (server.js / Express+PM2 custom server) ---
-
+# Server / deployment
 # "development" or "production" - controls whether server.js serves over
-# HTTPS (dev, using SSL_CERT_KEY/SSL_CERT_CRT) or plain HTTP (production).
-NODE_ENV=development
+# HTTPS (dev, using SSL_CERT_KEY/SSL_CERT_CRT) or plain HTTP (production),
+# and which .env.<NODE_ENV> file gets loaded.
+NODE_ENV=
+# Directory passed to cnad.config() - the @bitc/cnad process/restart watcher
+# used to manage the app on the deployment host.
+NODE_DIR=
+# File path that cnad.watch() monitors; touching/modifying this file triggers
+# an app restart on the deployment host.
+RESTART_FILE_PATH=
+# PEM-formatted TLS private key content used by the local HTTPS dev server
+# (https.createServer key in server.js).
+SSL_CERT_KEY=
+# PEM-formatted TLS certificate content used by the local HTTPS dev server
+# (https.createServer cert in server.js).
+SSL_CERT_CRT=
+# Port the Express server listens on, in both production (HTTP) and
+# non-production (local HTTPS) modes.
+APP_PORT=
+# Value written to the Access-Control-Allow-Origin response header for every
+# route (see headers() in next.config.mjs).
+ALLOWED_ORIGIN=
 
-# Absolute path to the Node installation directory used by the PM2 restart
-# watcher (@bitc/cnad) when redeploying.
-NODE_DIR=/path/to/node
-
-# Absolute path to the file that, when touched/modified, triggers a PM2 app
-# restart (watched by the deploy pipeline).
-RESTART_FILE_PATH=/path/to/restart.txt
-
-# Paths to the local TLS private key / certificate used for HTTPS in dev
-# (via `next dev --experimental-https`).
-SSL_CERT_KEY=/path/to/privkey.pem
-SSL_CERT_CRT=/path/to/fullchain.pem
-
-# Port the Express server listens on.
-APP_PORT=3000
-
-# Origin allowed by the CORS header set in next.config.mjs, e.g.
-# https://shaganplaatjies.co.za
-ALLOWED_ORIGIN=http://localhost:3000
-
-# --- WordPress (headless CMS content source) ---
-
-# Bare hostname of the WordPress instance content is fetched from, e.g.
-# blog.shaganplaatjies.co.za (used for both the REST API base and the
-# Next.js image remotePatterns host).
+# WordPress content source
+# Hostname of the WordPress instance backing the blog. Used to build the WP
+# REST API URLs in app/lib/server-lib.ts and as the allowed image
+# remotePatterns hostname for next/image in next.config.mjs.
 WP_DOMAIN=
+# Base path of the WordPress JSON REST API on WP_DOMAIN, used to build the
+# categories/tags/media/projects endpoint URLs in app/lib/server-lib.ts.
+WP_JSON_API_URI=
+# Path appended to WP_DOMAIN to build the WordPress posts endpoint URL in
+# app/lib/server-lib.ts.
+WP_POSTS_URI=
 
-# Path segment for the WordPress REST API root, appended to WP_DOMAIN, e.g.
-# /wp-json.
-WP_JSON_API_URI=/wp-json
-
-# Path segment for the WordPress posts endpoint, appended to the JSON API
-# base, e.g. /wp/v2/posts.
-WP_POSTS_URI=/wp/v2/posts
-
-# --- Email (contact form) ---
-
-# API key for the Resend transactional email service used by
-# app/api/contact/route.tsx to deliver contact form submissions.
+# Email (contact form)
+# API key for Resend, used to send email from the contact form API route
+# (app/api/contact/route.tsx).
 RESEND_API_KEY=
 
-# --- Public / client-exposed (NEXT_PUBLIC_* is inlined into the browser bundle) ---
-
-# Blog name shown in BlogHeader/BlogFooter.
-NEXT_PUBLIC_BLOG_NAME="Shagan Plaatjies"
-
-# Blog description/tagline shown in BlogHeader/BlogFooter.
-NEXT_PUBLIC_BLOG_DESCRIPTION="My slice of the silicone sea"
-
-# Public base URL of the blog, used for links in BlogHeader/BlogFooter.
-NEXT_PUBLIC_BLOG_URL=https://shaganplaatjies.co.za
-
-# --- Deploy pipeline only (not read directly by app source) ---
-
-# URL the deploy workflow uses to fetch/verify the downloadable resume PDF.
-# Not currently read via process.env in application code - required as a
-# GitHub Actions secret by .github/workflows/deploy-to-cpanel.yml.
+# Public / client-exposed (NEXT_PUBLIC_* vars are inlined into the browser bundle)
+# Blog site name shown in the blog header/footer (app/components/blog/BlogHeader.tsx,
+# BlogFooter.tsx). Falls back to "Shagan Plaatjies Blog" if unset.
+NEXT_PUBLIC_BLOG_NAME=
+# Blog tagline shown in the blog header/footer. Falls back to
+# "Thoughts on software development and technology" if unset.
+NEXT_PUBLIC_BLOG_DESCRIPTION=
+# Base URL/path used for blog links in the blog header/footer. Falls back to
+# "/blog" if unset.
+NEXT_PUBLIC_BLOG_URL=
+# Resume download link, set as a build-time secret in the deploy workflow
+# (.github/workflows/deploy-to-cpanel.yml). Not currently read via
+# process.env in application code - the resume link in
+# app/sections/ResumeSection.tsx points at a static file under
+# /public/downloads instead.
 PUBLIC_RESUME_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,67 @@
+# Copy this file to .env / .env.local / .env.development / .env.production
+# (as appropriate) and fill in real values. Never commit the filled-in files.
+
+# --- Server (server.js / Express+PM2 custom server) ---
+
+# "development" or "production" - controls whether server.js serves over
+# HTTPS (dev, using SSL_CERT_KEY/SSL_CERT_CRT) or plain HTTP (production).
+NODE_ENV=development
+
+# Absolute path to the Node installation directory used by the PM2 restart
+# watcher (@bitc/cnad) when redeploying.
+NODE_DIR=/path/to/node
+
+# Absolute path to the file that, when touched/modified, triggers a PM2 app
+# restart (watched by the deploy pipeline).
+RESTART_FILE_PATH=/path/to/restart.txt
+
+# Paths to the local TLS private key / certificate used for HTTPS in dev
+# (via `next dev --experimental-https`).
+SSL_CERT_KEY=/path/to/privkey.pem
+SSL_CERT_CRT=/path/to/fullchain.pem
+
+# Port the Express server listens on.
+APP_PORT=3000
+
+# Origin allowed by the CORS header set in next.config.mjs, e.g.
+# https://shaganplaatjies.co.za
+ALLOWED_ORIGIN=http://localhost:3000
+
+# --- WordPress (headless CMS content source) ---
+
+# Bare hostname of the WordPress instance content is fetched from, e.g.
+# blog.shaganplaatjies.co.za (used for both the REST API base and the
+# Next.js image remotePatterns host).
+WP_DOMAIN=
+
+# Path segment for the WordPress REST API root, appended to WP_DOMAIN, e.g.
+# /wp-json.
+WP_JSON_API_URI=/wp-json
+
+# Path segment for the WordPress posts endpoint, appended to the JSON API
+# base, e.g. /wp/v2/posts.
+WP_POSTS_URI=/wp/v2/posts
+
+# --- Email (contact form) ---
+
+# API key for the Resend transactional email service used by
+# app/api/contact/route.tsx to deliver contact form submissions.
+RESEND_API_KEY=
+
+# --- Public / client-exposed (NEXT_PUBLIC_* is inlined into the browser bundle) ---
+
+# Blog name shown in BlogHeader/BlogFooter.
+NEXT_PUBLIC_BLOG_NAME="Shagan Plaatjies"
+
+# Blog description/tagline shown in BlogHeader/BlogFooter.
+NEXT_PUBLIC_BLOG_DESCRIPTION="My slice of the silicone sea"
+
+# Public base URL of the blog, used for links in BlogHeader/BlogFooter.
+NEXT_PUBLIC_BLOG_URL=https://shaganplaatjies.co.za
+
+# --- Deploy pipeline only (not read directly by app source) ---
+
+# URL the deploy workflow uses to fetch/verify the downloadable resume PDF.
+# Not currently read via process.env in application code - required as a
+# GitHub Actions secret by .github/workflows/deploy-to-cpanel.yml.
+PUBLIC_RESUME_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 # all environment
 .env.*
 .env
+!.env.example
 
 # vercel
 */.vercel


### PR DESCRIPTION
## Summary
- Adds a committed `.env.example` documenting every environment variable the app/server actually reads (server config, WordPress source, Resend, public/client-exposed vars) plus the deploy-only `PUBLIC_RESUME_URL` secret, each with a one-line purpose comment and no real values.
- Adds a `!.env.example` exception to `.gitignore`, which otherwise blanket-ignores `.env.*`.

Addresses docs/improvement-notes/06-missing-env-example.md.

## Test plan
- [x] Confirmed via grep that the variable list matches every `process.env.*` reference in source, plus `PUBLIC_RESUME_URL` from the deploy workflow's secrets list.
- [x] Confirmed `git status` shows `.env.example` as trackable (not re-ignored by `.env.*`).