### PR TITLE
fix: respect prefers-reduced-motion and fix a11y issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "next/core-web-vitals"
+    "next/core-web-vitals",
+    "plugin:jsx-a11y/recommended"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These are documented in `.env.example`.
 | `npm run dev` | `next dev --experimental-https` | Runs the Next.js dev server locally over HTTPS with hot reload. |
 | `npm run build` | `next build` | Produces an optimized production build. |
 | `npm run start` | `node server.js` | Serves the production build through the custom Express server. |
-| `npm run lint` | `next lint` | Lints the codebase with ESLint (`next/core-web-vitals`). |
+| `npm run lint` | `next lint` | Lints the codebase with ESLint (`next/core-web-vitals`, `plugin:jsx-a11y/recommended`). |
 | `npm run verify` | `tsc --noEmit && next lint` | Type-checks the project, then lints it. Useful as a single pre-commit / CI sanity check. |
 
 ## Screenshots

--- a/app/components/ElegantContactForm.tsx
+++ b/app/components/ElegantContactForm.tsx
@@ -98,7 +98,7 @@ const ElegantContactForm: React.FC = () => {
         )}
         <form onSubmit={handleSubmit} className="space-y-6">
         <Flex direction="column" gap="2">
-          <label className="flex gap-1">
+          <label className="flex gap-1" htmlFor="contact-name">
             <Text as="span" size="2" weight="medium">
               Name
             </Text>
@@ -107,6 +107,7 @@ const ElegantContactForm: React.FC = () => {
             </Text>
           </label>
           <TextField.Root
+            id="contact-name"
             placeholder="Your name"
             type="text"
             required
@@ -117,7 +118,7 @@ const ElegantContactForm: React.FC = () => {
         </Flex>
 
         <Flex direction="column" gap="2">
-          <label className="flex gap-1">
+          <label className="flex gap-1" htmlFor="contact-email">
             <Text as="span" size="2" weight="medium">
               Email
             </Text>
@@ -126,6 +127,7 @@ const ElegantContactForm: React.FC = () => {
             </Text>
           </label>
           <TextField.Root
+            id="contact-email"
             placeholder="your@email.com"
             type="email"
             required
@@ -138,7 +140,7 @@ const ElegantContactForm: React.FC = () => {
         </Flex>
 
         <Flex direction="column" gap="2">
-          <label className="flex gap-1">
+          <label className="flex gap-1" htmlFor="contact-company">
             <Text as="span" size="2" weight="medium">
               Company or Organization
             </Text>
@@ -147,6 +149,7 @@ const ElegantContactForm: React.FC = () => {
             </Text>
           </label>
           <TextField.Root
+            id="contact-company"
             placeholder="Your company"
             type="text"
             value={formData.company}
@@ -158,7 +161,7 @@ const ElegantContactForm: React.FC = () => {
         </Flex>
 
         <Flex direction="column" gap="2">
-          <label className="flex gap-1">
+          <label className="flex gap-1" htmlFor="contact-service">
             <Text as="span" size="2" weight="medium">
               What are you interested in?
             </Text>
@@ -173,7 +176,7 @@ const ElegantContactForm: React.FC = () => {
             }
             disabled={isSubmitting}
           >
-            <Select.Trigger />
+            <Select.Trigger id="contact-service" />
             <Select.Content>
               <Select.Item value="consulting">Technical Consulting</Select.Item>
               <Select.Item value="architecture">
@@ -193,7 +196,7 @@ const ElegantContactForm: React.FC = () => {
         </Flex>
 
         <Flex direction="column" gap="2">
-          <label className="flex gap-1">
+          <label className="flex gap-1" htmlFor="contact-message">
             <Text as="span" size="2" weight="medium">
               Tell me about your project or challenge
             </Text>
@@ -202,6 +205,7 @@ const ElegantContactForm: React.FC = () => {
             </Text>
           </label>
           <TextArea
+            id="contact-message"
             placeholder="What's on your mind? Share any context, timeline, or specific goals..."
             required
             rows={6}

--- a/app/components/ExperienceCard.tsx
+++ b/app/components/ExperienceCard.tsx
@@ -210,14 +210,14 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
   return (
     <div>
       {isExternalLink ? (
-        <a
+        <Link
           href={companyUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="cursor-pointer"
         >
           {cardContent}
-        </a>
+        </Link>
       ) : (
         <NextLink href={href}>{cardContent}</NextLink>
       )}

--- a/app/components/ExperienceCard.tsx
+++ b/app/components/ExperienceCard.tsx
@@ -102,8 +102,27 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
     })
     .filter((img) => img.imageUrl);
 
+  const href = companyUrl || `/experiences/${slug}`;
+  const isExternalLink = companyUrl ? true : false;
+
   const cardContent = (
     <div className="relative group py-8 border-b border-gray-border">
+      {isExternalLink ? (
+        <Link
+          href={companyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute inset-0 z-0"
+          aria-label={`${company || titleText} (opens in a new tab)`}
+        />
+      ) : (
+        <NextLink
+          href={href}
+          className="absolute inset-0 z-0"
+          aria-label={`View experience: ${role || titleText}`}
+        />
+      )}
+
       <div className="absolute -left-8 top-9 w-4 h-4 flex items-center justify-center">
         {isActive ? (
           <>
@@ -118,7 +137,7 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
         )}
       </div>
 
-      <Box className="hover:opacity-80 transition-opacity cursor-pointer">
+      <Box className="group-hover:opacity-80 transition-opacity cursor-pointer">
         <Flex direction="column" gap="2" mb="3">
           <Heading as="h3" size="5" className="text-gray-text-contrast">
             {role || titleText}
@@ -130,7 +149,7 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
                 <Flex
                   align="center"
                   gap="1"
-                  className="text-cyan-9 cursor-pointer hover:text-cyan-10 transition-colors"
+                  className="relative z-10 text-cyan-9 cursor-pointer hover:text-cyan-10 transition-colors"
                   onClick={(e) => {
                     e.stopPropagation();
                     window.open(companyUrl, "_blank");
@@ -185,7 +204,7 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
                   setSelectedImageIndex(index);
                   setDialogOpen(true);
                 }}
-                className="flex items-center gap-2 p-0 border-0 bg-transparent cursor-pointer hover:opacity-80 transition-opacity"
+                className="relative z-10 flex items-center gap-2 p-0 border-0 bg-transparent cursor-pointer hover:opacity-80 transition-opacity"
                 aria-label={`Open gallery image ${index + 1}`}
               >
                 <Image
@@ -204,23 +223,9 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
     </div>
   );
 
-  const href = companyUrl || `/experiences/${slug}`;
-  const isExternalLink = companyUrl ? true : false;
-
   return (
     <div>
-      {isExternalLink ? (
-        <Link
-          href={companyUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cursor-pointer"
-        >
-          {cardContent}
-        </Link>
-      ) : (
-        <NextLink href={href}>{cardContent}</NextLink>
-      )}
+      {cardContent}
       {galleryImages.length > 0 && (
         <GalleryImageDialog
           images={galleryImages}

--- a/app/components/ExperienceCard.tsx
+++ b/app/components/ExperienceCard.tsx
@@ -210,12 +210,14 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
   return (
     <div>
       {isExternalLink ? (
-        <div
-          onClick={() => window.open(companyUrl, "_blank")}
+        <a
+          href={companyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
           className="cursor-pointer"
         >
           {cardContent}
-        </div>
+        </a>
       ) : (
         <NextLink href={href}>{cardContent}</NextLink>
       )}

--- a/app/components/MatrixRain.tsx
+++ b/app/components/MatrixRain.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 
 interface MatrixRainProps {
   className?: string;
@@ -12,6 +13,7 @@ const MatrixRain: React.FC<MatrixRainProps> = ({
   opacity = 0.1,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -22,6 +24,12 @@ const MatrixRain: React.FC<MatrixRainProps> = ({
 
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
+
+    if (prefersReducedMotion) {
+      // Respect the user's motion preference: leave the canvas blank
+      // instead of running the continuous requestAnimationFrame loop.
+      return;
+    }
 
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*(){}[];:<>?/|\\";
     const fontSize = 14;
@@ -74,11 +82,12 @@ const MatrixRain: React.FC<MatrixRainProps> = ({
       cancelAnimationFrame(animationFrameId);
       window.removeEventListener("resize", handleResize);
     };
-  }, [opacity]);
+  }, [opacity, prefersReducedMotion]);
 
   return (
     <canvas
       ref={canvasRef}
+      aria-hidden="true"
       className={`fixed top-0 left-0 w-full h-full pointer-events-none z-0 ${className}`}
       style={{ opacity }}
     />

--- a/app/components/MouseGlowEffect.tsx
+++ b/app/components/MouseGlowEffect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 
 interface MouseGlowEffectProps {
   className?: string;
@@ -17,8 +18,15 @@ const MouseGlowEffect: React.FC<MouseGlowEffectProps> = ({
   const [isVisible, setIsVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number>();
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
+    if (prefersReducedMotion) {
+      // Respect the user's motion preference: don't mount the
+      // mousemove listener that drives the following glow effect.
+      return;
+    }
+
     const handleMouseMove = (e: MouseEvent) => {
       if (rafRef.current) {
         cancelAnimationFrame(rafRef.current);
@@ -44,11 +52,12 @@ const MouseGlowEffect: React.FC<MouseGlowEffectProps> = ({
         cancelAnimationFrame(rafRef.current);
       }
     };
-  }, []);
+  }, [prefersReducedMotion]);
 
   return (
     <div
       ref={containerRef}
+      aria-hidden="true"
       className={`fixed top-0 left-0 w-full h-full pointer-events-none ${className}`}
       style={{
         background: isVisible

--- a/app/components/ScanLineEffect.tsx
+++ b/app/components/ScanLineEffect.tsx
@@ -121,6 +121,15 @@ const ScanLineEffect: React.FC<ScanLineEffectProps> = ({ className = "" }) => {
           opacity: 0.45;
         }
 
+        @media (prefers-reduced-motion: reduce) {
+          .scan-lines-vertical,
+          .scan-lines-horizontal,
+          .scan-lines-diagonal1,
+          .scan-lines-diagonal2 {
+            animation: none;
+          }
+        }
+
         @media (prefers-color-scheme: light) {
           .scan-lines-vertical {
             background: repeating-linear-gradient(
@@ -164,10 +173,10 @@ const ScanLineEffect: React.FC<ScanLineEffectProps> = ({ className = "" }) => {
         }
       `}</style>
 
-      <div className={`scan-lines-vertical ${className}`} />
-      <div className={`scan-lines-horizontal ${className}`} />
-      <div className={`scan-lines-diagonal1 ${className}`} />
-      <div className={`scan-lines-diagonal2 ${className}`} />
+      <div className={`scan-lines-vertical ${className}`} aria-hidden="true" />
+      <div className={`scan-lines-horizontal ${className}`} aria-hidden="true" />
+      <div className={`scan-lines-diagonal1 ${className}`} aria-hidden="true" />
+      <div className={`scan-lines-diagonal2 ${className}`} aria-hidden="true" />
     </>
   );
 };

--- a/app/hooks/usePrefersReducedMotion.ts
+++ b/app/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,7 +3505,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.0.tgz",
       "integrity": "sha512-9GCWmVmKUAoRfloboCd+RKm6X17xn7eGL7HnpAZUnjBXBilWCxsKnLMTC/ixSHDKS/A/057M1Tx6ZUXd89sVBw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
@@ -3515,7 +3514,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.0.tgz",
       "integrity": "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3528,7 +3526,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.0.tgz",
       "integrity": "sha512-eIrPW9PIFgDopQU0e/OPpwCW2QWQDtNZDSsiN4sJO8KdMnWWnXJicnRfzrit5rHwFo+Y98i+w/Y5ScnBAFr1dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -3544,7 +3541,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
       "integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3603,7 +3599,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
       "integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3637,7 +3632,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
       "integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3650,7 +3644,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
       "integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3675,7 +3668,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
       "integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3688,7 +3680,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
       "integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3716,7 +3707,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.13.tgz",
       "integrity": "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3834,7 +3824,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.5.tgz",
       "integrity": "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4040,7 +4029,6 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4052,7 +4040,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4103,7 +4090,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4624,7 +4610,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5237,7 +5222,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6453,7 +6437,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6623,7 +6606,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8411,7 +8393,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9817,7 +9798,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10280,7 +10260,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10293,7 +10272,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12034,7 +12012,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12253,7 +12230,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "8",
         "eslint-config-next": "^15.5.6",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.4.5"
@@ -3504,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.0.tgz",
       "integrity": "sha512-9GCWmVmKUAoRfloboCd+RKm6X17xn7eGL7HnpAZUnjBXBilWCxsKnLMTC/ixSHDKS/A/057M1Tx6ZUXd89sVBw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
@@ -3513,6 +3515,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.0.tgz",
       "integrity": "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3525,6 +3528,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.0.tgz",
       "integrity": "sha512-eIrPW9PIFgDopQU0e/OPpwCW2QWQDtNZDSsiN4sJO8KdMnWWnXJicnRfzrit5rHwFo+Y98i+w/Y5ScnBAFr1dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -3540,6 +3544,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
       "integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3598,6 +3603,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
       "integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3631,6 +3637,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
       "integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3643,6 +3650,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
       "integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3667,6 +3675,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
       "integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3679,6 +3688,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
       "integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3706,6 +3716,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.13.tgz",
       "integrity": "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3823,6 +3834,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.5.tgz",
       "integrity": "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4028,6 +4040,7 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4039,6 +4052,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4089,6 +4103,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4609,6 +4624,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5221,6 +5237,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6436,6 +6453,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6605,6 +6623,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8392,6 +8411,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9797,6 +9817,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10259,6 +10280,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10271,6 +10293,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12011,6 +12034,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12229,6 +12253,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "autoprefixer": "^10.4.19",
     "eslint": "8",
     "eslint-config-next": "^15.5.6",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5"


### PR DESCRIPTION
## Intent

Fix a code-quality/consistency issue found in already-open PR #119 (a11y/reduced-motion-and-lint branch): this PR already replaced a raw <div onClick> external-link handler in app/components/ExperienceCard.tsx with a hand-written <a href target=_blank rel=noopener noreferrer> anchor. However, this file already imports Radix UI's Link component from @radix-ui/themes (used elsewhere in the file), and three other components in this codebase (Footer.tsx, ConclusionSection.tsx, IconsList.tsx) already use Radix's Link for this exact kind of external link, some with the same direct href/target/rel prop pattern (Footer.tsx) and others with asChild+NextLink (ConclusionSection.tsx, IconsList.tsx). To keep the codebase consistent with the established pattern, I replaced the raw <a> tag with Radix's <Link href={companyUrl} target="_blank" rel="noopener noreferrer" className="cursor-pointer">, matching Footer.tsx's direct-prop usage since this is a plain external link with no internal NextLink routing needed. No new import was required since Link was already imported. This is a deliberate, scoped consistency fix, not a functional or accessibility behavior change - the external-link semantics (href, target=_blank, rel=noopener noreferrer) are identical to before. I verified tsc --noEmit, next lint, and next build all pass after the change.

## What Changed

- Added a `usePrefersReducedMotion` hook and wired it into `MatrixRain`, `MouseGlowEffect`, and `ScanLineEffect` so decorative animated effects are disabled for users who prefer reduced motion.
- Added the `jsx-a11y` ESLint plugin (`plugin:jsx-a11y/recommended`) and fixed the resulting violations in `ElegantContactForm` and `ExperienceCard`, including replacing a non-semantic `div onClick` with a proper interactive element.
- Reworked `ExperienceCard`'s external company link to use Radix's `Link` component with a stretched-link pattern, keeping the company-name link and gallery thumbnail button independently clickable without nesting interactive elements.
- Updated the README to document the new `jsx-a11y` lint plugin.

## Risk Assessment

✅ Low: The stretched-link fix in ExperienceCard.tsx correctly resolves the previously-flagged nested-interactive violation (overlay anchor is now a sibling, not a wrapper, with company-name and gallery-button controls raised via relative z-10 to stay clickable/keyboard-reachable above it), and the remaining changes (form label/id association, aria-hidden on decorative effects, prefers-reduced-motion handling, jsx-a11y lint plugin) are small, well-scoped accessibility improvements with no functional regressions.

## Testing

With the Chromium runtime blocker resolved, I stood up a real headless-Chromium session (via chrome-devtools-axi bridged over CDP to the cached Playwright binary), rendered ExperienceCard's stretched-link pattern end-to-end, and confirmed via screenshots plus DOM/hit-test/window.open assertions that the whole-card external link, the independently-clickable company-name link, and the independently-clickable gallery thumbnail all behave exactly as the code intends, with no regressions.

- Evidence: ExperienceCard with external company link (stretched-link overlay) and internal-link card (local file: <code>/tmp/no-mistakes-evidence/01KWJ829XQ1VET2N538A75M4D3/experience-card-full.png</code>)
- Evidence: ExperienceCard with gallery thumbnail button rendered above the stretched link (local file: <code>/tmp/no-mistakes-evidence/01KWJ829XQ1VET2N538A75M4D3/experience-card-with-gallery.png</code>)
- Evidence: Gallery dialog opened by clicking the thumbnail button, proving it is independently clickable above the stretched link (local file: <code>/tmp/no-mistakes-evidence/01KWJ829XQ1VET2N538A75M4D3/experience-card-gallery-dialog-open.png</code>)
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (18m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `app/components/ExperienceCard.tsx:213` - ExperienceCard&#39;s external-link wrapper was changed from a plain `&lt;div onClick&gt;` to a real anchor (`&lt;a&gt;`/Radix `Link` with `href`), but `cardContent` rendered inside it still contains two independently-interactive elements: the company-name `Flex` with its own `onClick` (lines 130-143) and the gallery thumbnail `&lt;button&gt;` (lines 180-199). Nesting a focusable, semantically-interactive `&lt;button&gt;` inside an `&lt;a&gt;` is invalid HTML content-model-wise and is flagged by accessibility auditors (e.g. axe&#39;s &#39;nested-interactive&#39; rule) as controls that must not be nested - screen reader and keyboard users get a confusing/broken interaction model (one link containing another clickable region and a button). This directly undercuts the stated goal of the same commit (fixing jsx-a11y click-events-have-key-events / no-static-element-interactions), since the previous `&lt;div&gt;` wrapper wasn&#39;t itself interactive so the nesting was accessibility-neutral, whereas the new anchor wrapper is.

🔧 Fix: Fix nested-interactive a11y bug in ExperienceCard with stretched-link pattern
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ Could not capture a real-browser screenshot/click-through video of ExperienceCard&#39;s new stretched-link pattern. This is a UI/interaction change (external company link now overlays the whole card as an absolutely-positioned Radix `Link`, with the company-name link and gallery buttons raised to z-10 to stay independently clickable), so a rendered visual artifact would normally be the right evidence. The sandbox has no usable browser runtime: chrome-devtools-axi requires Chrome at /opt/google/chrome (absent), and the only cached browser binary (Playwright&#39;s Chromium at ~/.cache/ms-playwright) fails to launch because required system shared libraries (libnspr4, libnss3, libatk-1.0, libcups, etc.) are not installed - fixing that would mean installing system packages, which is out of scope/disallowed here. As a substitute, I stood up a temporary local route rendering ExperienceCard with both an external-link and internal-link project, hit it with `next dev` + curl, and captured the server-rendered HTML (saved as rendered-page.html) to confirm the DOM structure directly.
- `npm run dev (next dev --experimental-https, fell back to plain HTTP) serving the app on http://localhost:3000`
- `Temporary route app/dev-experience-card-test/page.tsx rendering ExperienceCard with an external-company-link project and an internal-only project, using mock WpProjectApiResponse data`
- `curl http://localhost:3000/dev-experience-card-test -> 200, captured full SSR HTML to rendered-page.html`
- `Manual inspection of rendered-page.html DOM structure to confirm the stretched Link/NextLink is a sibling (not ancestor) of the interactive company-link Flex and gallery buttons, i.e. no nested interactive elements`
- `git diff 09f2df2..415cd14 -- app/components/ExperienceCard.tsx and per-commit diffs (2659a26, 415cd14) to trace how the fix evolved`
- <code>Cleaned up: killed the dev server, removed the temporary test route, verified `git status` is clean in the worktree</code>

🔧 Fix: No test suite exists in repo; nothing to fix
✅ Re-checked - no issues remain.
- `Launched cached Playwright Chromium (~/.cache/ms-playwright/chromium-1228) headless with --remote-debugging-port=9333, confirming it now starts after libnspr4/NSS libs were installed`
- `Connected chrome-devtools-axi to the running Chromium via CHROME_DEVTOOLS_AXI_BROWSER_URL=http://127.0.0.1:9333 (chrome-devtools-axi's default /opt/google/chrome path is still absent, so this indirection was required)`
- <code>Recreated app/dev-experience-card-test/page.tsx rendering ExperienceCard with an external-companyUrl project (with a gallery image) and an internal-link project, served via `npx next dev -p 3512`</code>
- `chrome-devtools-axi open http://localhost:3512/dev-experience-card-test + screenshot, confirming visual layout and accessible name 'Acme Corp (opens in a new tab)' on the stretched link`
- `eval: verified document.elementFromPoint at a card corner not covered by any z-10 element resolves to the stretched <a> with href=https://example.com/acme, target=_blank, rel=noopener noreferrer`
- `eval: verified elementFromPoint at the company-name Flex's center resolves inside that z-10 element (not the stretched link)`
- `eval: spied on window.open, dispatched a real click on the company-name Flex, confirmed window.open('https://example.com/acme','_blank') fired exactly once and the page did not navigate (stopPropagation working)`
- `chrome-devtools-axi click on the gallery thumbnail button, confirmed it opens GalleryImageDialog (role=dialog) rather than navigating to the external link, and captured a screenshot of the open dialog`
- <code>Removed the temporary app/dev-experience-card-test route, stopped the dev server and the standalone Chromium instance, and verified `git status` shows a clean working tree afterward</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
