### PR TITLE
test(e2e): add Playwright E2E coverage for contact form and content routes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E tests
+
+# Manual trigger only. This suite hits the real, live WordPress backend
+# (WP_DOMAIN) for the smoke tests, so it's deliberately kept out of the
+# PR-blocking gate - a WordPress hiccup shouldn't fail every PR.
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    env:
+      WP_DOMAIN: staging.blog.shaganplaatjies.co.za
+      WP_JSON_API_URI: /wp-json/wp/v2
+      WP_POSTS_URI: /wp-json/wp/v2/posts
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Resolve NODE_DIR for cnad
+        run: echo "NODE_DIR=$(dirname $(dirname $(which npm)))" >> "$GITHUB_ENV"
+
       - name: Run Playwright tests
         run: npm run test:e2e
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/blob-report
+/playwright/.cache
 
 # AI Agent
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Running Playwright E2E locally
+
+`npm run test:e2e` boots the app via `server.js` (`playwright.config.ts` webServer runs `npm run build && npm run start`), which requires `NODE_ENV=production`. `server.js` calls `cnad.config(process.env.NODE_DIR)` (a cPanel auto-deploy helper) on startup, and `cnad` exits the process immediately if `NODE_DIR` is unset - so a plain `npx playwright test` fails with `CNAD :::: Path to npm in production is required` before the server ever binds a port. Set `NODE_DIR` to the directory containing `bin/npm` (e.g. `NODE_DIR=$(dirname $(dirname $(which npm)))`) before running the suite.
+
+In a minimal sandbox with no system Chromium deps and no root access, `apt-get download <pkg>` (no sudo needed) + `dpkg-deb -x <pkg>.deb <prefix>` + `LD_LIBRARY_PATH=<prefix>/usr/lib/x86_64-linux-gnu` is a viable way to satisfy Chromium's shared-library requirements (libnspr4, libnss3, libatk*, libgtk-3-0, libpixman-1-0, libharfbuzz0b, libgraphite2-3, etc.) without `playwright install --with-deps`, which needs a password-less sudo that may not be available.
+
+## Test hooks in components
+
+`ElegantContactForm` (and its Playwright spec in `e2e/contact-form.spec.ts`) use `data-testid` attributes for stable selectors. Radix Themes components (`TextField.Root`, `TextArea`, `Select.Trigger`, `Button`) forward arbitrary DOM props, including `data-testid`, straight through to the real underlying `<input>`/`<textarea>`/`<button>` element (verified by reading `node_modules/@radix-ui/themes/dist/cjs/components/*.js`), so adding `data-testid` to these components works exactly like adding it to a plain HTML element.
+
+`PortfolioPageContent` renders its children twice (a desktop wrapper and a mobile wrapper, toggled by CSS), so every `data-testid` in `ElegantContactForm` exists twice in the DOM at once. Any Playwright selector built on these testids needs `.first()` to land on the visible desktop copy under the default viewport.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ These are documented in `.env.example`.
 | `npm run start` | `node server.js` | Serves the production build through the custom Express server. |
 | `npm run lint` | `next lint` | Lints the codebase with ESLint (`next/core-web-vitals`, `plugin:jsx-a11y/recommended`). |
 | `npm run verify` | `tsc --noEmit && next lint` | Type-checks the project, then lints it. Useful as a single pre-commit / CI sanity check. |
+| `npm run test:e2e` | `playwright test` | Runs the Playwright end-to-end suite against a production build (see Testing below). |
+
+## Testing
+
+End-to-end tests live under `e2e/` and run with [Playwright](https://playwright.dev/).
+`npm run test:e2e` builds the app and serves it through `server.js` (the same production entrypoint used in deployment), so it requires `NODE_DIR` to be set - see `AGENTS.md` for why and how.
+The suite is wired up as a manually-triggered GitHub Actions workflow (`.github/workflows/e2e.yml`) rather than a PR gate, since the smoke tests hit the real, live WordPress backend.
 
 ## Screenshots
 

--- a/app/components/ElegantContactForm.tsx
+++ b/app/components/ElegantContactForm.tsx
@@ -69,7 +69,7 @@ const ElegantContactForm: React.FC = () => {
 
   if (submitted) {
     return (
-      <Box className="text-center py-12">
+      <Box className="text-center py-12" data-testid="contact-success-message">
         <Text
           as="p"
           size="5"
@@ -90,13 +90,20 @@ const ElegantContactForm: React.FC = () => {
     <Flex justify="center" width="100%">
       <Box className="max-w-2xl w-full">
         {error && (
-          <Box className="mb-6 p-4 rounded-sm border border-gray-border-active bg-gray-bg-secondary">
+          <Box
+            className="mb-6 p-4 rounded-sm border border-gray-border-active bg-gray-bg-secondary"
+            data-testid="contact-error-message"
+          >
             <Text as="p" size="2" className="text-gray-solid">
               {error}
             </Text>
           </Box>
         )}
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6"
+          data-testid="contact-form"
+        >
         <Flex direction="column" gap="2">
           <label className="flex gap-1" htmlFor="contact-name">
             <Text as="span" size="2" weight="medium">
@@ -114,6 +121,7 @@ const ElegantContactForm: React.FC = () => {
             value={formData.name}
             onChange={(e) => setFormData({ ...formData, name: e.target.value })}
             disabled={isSubmitting}
+            data-testid="contact-name-input"
           />
         </Flex>
 
@@ -136,6 +144,7 @@ const ElegantContactForm: React.FC = () => {
               setFormData({ ...formData, email: e.target.value })
             }
             disabled={isSubmitting}
+            data-testid="contact-email-input"
           />
         </Flex>
 
@@ -157,6 +166,7 @@ const ElegantContactForm: React.FC = () => {
               setFormData({ ...formData, company: e.target.value })
             }
             disabled={isSubmitting}
+            data-testid="contact-company-input"
           />
         </Flex>
 
@@ -176,7 +186,10 @@ const ElegantContactForm: React.FC = () => {
             }
             disabled={isSubmitting}
           >
-            <Select.Trigger id="contact-service" />
+            <Select.Trigger
+              id="contact-service"
+              data-testid="contact-service-select"
+            />
             <Select.Content>
               <Select.Item value="consulting">Technical Consulting</Select.Item>
               <Select.Item value="architecture">
@@ -214,6 +227,7 @@ const ElegantContactForm: React.FC = () => {
               setFormData({ ...formData, message: e.target.value })
             }
             disabled={isSubmitting}
+            data-testid="contact-message-input"
           />
         </Flex>
 
@@ -224,6 +238,7 @@ const ElegantContactForm: React.FC = () => {
             color="cyan"
             variant="ghost"
             className="font-semibold"
+            data-testid="contact-submit"
           >
             {isSubmitting ? "Sending..." : "Let's Connect"}
           </Button>

--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+// PortfolioPageContent renders its children twice - once in a "hidden
+// sm:flex" desktop wrapper, once in a "sm:hidden flex" mobile wrapper - so
+// the contact form (and every field in it) exists twice in the DOM at all
+// times, with CSS controlling which copy is visible. The desktop wrapper is
+// declared first in the JSX, so scoping to the first <form> lands on the
+// one visible copy under the default (desktop) viewport used by this project.
+test.describe("contact form", () => {
+  test("happy path shows the success state", async ({ page }) => {
+    await page.route("**/api/contact", (route) =>
+      route.fulfill({ status: 200, json: { success: true } })
+    );
+
+    await page.goto("/");
+
+    const form = page.locator("form").first();
+
+    await form.getByPlaceholder("Your name").fill("Ada Lovelace");
+    await form.getByPlaceholder("your@email.com").fill("ada@example.com");
+    await form.getByPlaceholder("Your company").fill("Analytical Engines Ltd");
+    await form.getByRole("combobox").click();
+    await page.getByRole("option", { name: "System Architecture" }).click();
+    await form
+      .getByPlaceholder("What's on your mind? Share any context, timeline, or specific goals...")
+      .fill("Testing the contact form happy path.");
+
+    await form.getByRole("button", { name: "Let's Connect" }).click();
+
+    await expect(page.getByText("Thank you for reaching out")).toBeVisible();
+  });
+
+  test("error response surfaces the error state", async ({ page }) => {
+    await page.route("**/api/contact", (route) =>
+      route.fulfill({ status: 500, json: { error: "Failed to send email" } })
+    );
+
+    await page.goto("/");
+
+    const form = page.locator("form").first();
+
+    await form.getByPlaceholder("Your name").fill("Ada Lovelace");
+    await form.getByPlaceholder("your@email.com").fill("ada@example.com");
+    await form.getByPlaceholder("Your company").fill("Analytical Engines Ltd");
+    await form.getByRole("combobox").click();
+    await page.getByRole("option", { name: "System Architecture" }).click();
+    await form
+      .getByPlaceholder("What's on your mind? Share any context, timeline, or specific goals...")
+      .fill("Testing the contact form error path.");
+
+    await form.getByRole("button", { name: "Let's Connect" }).click();
+
+    await expect(
+      page.getByText("Failed to send message. Please try again.")
+    ).toBeVisible();
+  });
+});

--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from "@playwright/test";
 
 // PortfolioPageContent renders its children twice - once in a "hidden
 // sm:flex" desktop wrapper, once in a "sm:hidden flex" mobile wrapper - so
-// the contact form (and every field in it) exists twice in the DOM at all
-// times, with CSS controlling which copy is visible. The desktop wrapper is
-// declared first in the JSX, so scoping to the first <form> lands on the
-// one visible copy under the default (desktop) viewport used by this project.
+// the contact form (and every field in it, including their data-testid
+// attributes) exists twice in the DOM at all times, with CSS controlling
+// which copy is visible. The desktop wrapper is declared first in the JSX,
+// so scoping to the first match lands on the one visible copy under the
+// default (desktop) viewport used by this project.
 test.describe("contact form", () => {
   test("happy path shows the success state", async ({ page }) => {
     await page.route("**/api/contact", (route) =>
@@ -14,20 +15,24 @@ test.describe("contact form", () => {
 
     await page.goto("/");
 
-    const form = page.locator("form").first();
+    const form = page.getByTestId("contact-form").first();
 
-    await form.getByPlaceholder("Your name").fill("Ada Lovelace");
-    await form.getByPlaceholder("your@email.com").fill("ada@example.com");
-    await form.getByPlaceholder("Your company").fill("Analytical Engines Ltd");
-    await form.getByRole("combobox").click();
+    await form.getByTestId("contact-name-input").fill("Ada Lovelace");
+    await form.getByTestId("contact-email-input").fill("ada@example.com");
+    await form
+      .getByTestId("contact-company-input")
+      .fill("Analytical Engines Ltd");
+    await form.getByTestId("contact-service-select").click();
     await page.getByRole("option", { name: "System Architecture" }).click();
     await form
-      .getByPlaceholder("What's on your mind? Share any context, timeline, or specific goals...")
+      .getByTestId("contact-message-input")
       .fill("Testing the contact form happy path.");
 
-    await form.getByRole("button", { name: "Let's Connect" }).click();
+    await form.getByTestId("contact-submit").click();
 
-    await expect(page.getByText("Thank you for reaching out")).toBeVisible();
+    await expect(
+      page.getByTestId("contact-success-message").first()
+    ).toBeVisible();
   });
 
   test("error response surfaces the error state", async ({ page }) => {
@@ -37,21 +42,23 @@ test.describe("contact form", () => {
 
     await page.goto("/");
 
-    const form = page.locator("form").first();
+    const form = page.getByTestId("contact-form").first();
 
-    await form.getByPlaceholder("Your name").fill("Ada Lovelace");
-    await form.getByPlaceholder("your@email.com").fill("ada@example.com");
-    await form.getByPlaceholder("Your company").fill("Analytical Engines Ltd");
-    await form.getByRole("combobox").click();
+    await form.getByTestId("contact-name-input").fill("Ada Lovelace");
+    await form.getByTestId("contact-email-input").fill("ada@example.com");
+    await form
+      .getByTestId("contact-company-input")
+      .fill("Analytical Engines Ltd");
+    await form.getByTestId("contact-service-select").click();
     await page.getByRole("option", { name: "System Architecture" }).click();
     await form
-      .getByPlaceholder("What's on your mind? Share any context, timeline, or specific goals...")
+      .getByTestId("contact-message-input")
       .fill("Testing the contact form error path.");
 
-    await form.getByRole("button", { name: "Let's Connect" }).click();
+    await form.getByTestId("contact-submit").click();
 
     await expect(
-      page.getByText("Failed to send message. Please try again.")
+      page.getByTestId("contact-error-message").first()
     ).toBeVisible();
   });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+// These hit the real, live WordPress backend (WP_DOMAIN) rather than a mock -
+// acceptable for a personal site with a stable, always-on headless CMS. Named
+// "(live WP)" so a WordPress hiccup isn't mistaken for a code regression.
+
+test("smoke: blog post renders (live WP)", async ({ page }) => {
+  await page.goto("/blog");
+
+  const postLink = page.locator('a[href^="/blog/posts/"]').first();
+  await expect(postLink).toBeVisible();
+  await postLink.click();
+
+  await expect(page).toHaveURL(/\/blog\/posts\//);
+  await expect(page.locator("h1, h2").first()).toBeVisible();
+});
+
+test("smoke: project page renders (live WP)", async ({ page }) => {
+  await page.goto("/projects");
+
+  // ProjectCard can link out to an external companyUrl instead of the
+  // internal slug page, so select the internal link specifically.
+  const projectLink = page.locator('a[href^="/projects/"]').first();
+  await expect(projectLink).toBeVisible();
+  await projectLink.click();
+
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.locator("h1, h2").first()).toBeVisible();
+});
+
+test("smoke: experience page renders (live WP)", async ({ page }) => {
+  // The listing page is singular ("/experience"); detail routes are plural
+  // ("/experiences/[slug]") - intentional split in this codebase, not a typo.
+  await page.goto("/experience");
+
+  // ExperienceCard can also link out to an external companyUrl.
+  const experienceLink = page.locator('a[href^="/experiences/"]').first();
+  await expect(experienceLink).toBeVisible();
+  await experienceLink.click();
+
+  await expect(page).toHaveURL(/\/experiences\//);
+  await expect(page.locator("h1, h2").first()).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "swr": "^2.2.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^22.0.0",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1584,6 +1585,23 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pm2/agent": {
@@ -3505,6 +3523,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.0.tgz",
       "integrity": "sha512-9GCWmVmKUAoRfloboCd+RKm6X17xn7eGL7HnpAZUnjBXBilWCxsKnLMTC/ixSHDKS/A/057M1Tx6ZUXd89sVBw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
@@ -3514,6 +3533,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.0.tgz",
       "integrity": "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3526,6 +3546,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.0.tgz",
       "integrity": "sha512-eIrPW9PIFgDopQU0e/OPpwCW2QWQDtNZDSsiN4sJO8KdMnWWnXJicnRfzrit5rHwFo+Y98i+w/Y5ScnBAFr1dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -3541,6 +3562,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
       "integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3599,6 +3621,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
       "integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3632,6 +3655,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
       "integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3644,6 +3668,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
       "integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3668,6 +3693,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
       "integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3680,6 +3706,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
       "integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3707,6 +3734,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.13.tgz",
       "integrity": "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3824,6 +3852,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.5.tgz",
       "integrity": "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4029,6 +4058,7 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4040,6 +4070,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4090,6 +4121,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4610,6 +4642,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5222,6 +5255,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6437,6 +6471,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6606,6 +6641,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8393,6 +8429,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9631,6 +9668,53 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pm2": {
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/pm2/-/pm2-6.0.13.tgz",
@@ -9798,6 +9882,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10260,6 +10345,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10272,6 +10358,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12012,6 +12099,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12230,6 +12318,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "node server.js",
     "lint": "next lint",
-    "verify": "tsc --noEmit && next lint"
+    "verify": "tsc --noEmit && next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@bitc/cnad": "^1.1.0",
@@ -36,6 +37,7 @@
     "swr": "^2.2.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.0.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// server.js (our custom Express/PM2 entrypoint) only serves plain HTTP when
+// NODE_ENV=production - otherwise it takes the local-SSL branch and expects
+// dev certs. We pin a fixed port here (rather than relying on whatever
+// APP_PORT happens to be in .env.production) so baseURL always matches the
+// server webServer spins up below.
+const PORT = "4310";
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  timeout: 60_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  // Build + start via the real npm scripts so we exercise the same
+  // server.js entrypoint used in production, not `next start` directly.
+  webServer: {
+    command: "npm run build && npm run start",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    // Generous timeout: this runs a full `next build` before starting the
+    // server, which can take a while on a loaded/shared machine.
+    timeout: 600_000,
+    env: {
+      NODE_ENV: "production",
+      APP_PORT: PORT,
+      WP_DOMAIN: process.env.WP_DOMAIN ?? "staging.blog.shaganplaatjies.co.za",
+      WP_JSON_API_URI: process.env.WP_JSON_API_URI ?? "/wp-json/wp/v2",
+      WP_POSTS_URI: process.env.WP_POSTS_URI ?? "/wp-json/wp/v2/posts",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Intent

Fix a code-quality issue flagged on open PR #121 (Playwright E2E coverage): ElegantContactForm.tsx had no id/name/data-testid attributes on any field, forcing e2e/contact-form.spec.ts into brittle selectors (page.locator("form").first(), getByPlaceholder text matches, getByText on success/error copy). Added data-testid attributes to the form element, every field (name, email, company, service select, message), the submit button, and the success/error message containers, then rewrote the spec to use page.getByTestId(...) for all of these instead. Left e2e/smoke.spec.ts untouched (out of scope). Note: the contact form is rendered twice in the DOM (desktop+mobile copies via PortfolioPageContent), so both the old and new specs deliberately use .first() to land on the visible desdesktop copy - this is intentional, not a duplicate-testid bug. Verified locally: tsc --noEmit clean, next lint clean, and a real Playwright run (had to manually resolve missing system shared libraries and set NODE_DIR since this is a minimal sandbox) - both contact-form.spec.ts tests pass end-to-end. Also added AGENTS.md/CLAUDE.md documenting the NODE_DIR requirement and Radix Themes' data-testid prop forwarding, since neither file existed before and this task uncovered non-obvious project setup knowledge.

## What Changed

- Added Playwright config, a smoke spec for content routes, and a contact-form spec, plus a `workflow_dispatch` GitHub Actions workflow (with `NODE_DIR` set so `cnad` doesn't exit early on the production server boot) to run the suite.
- Added `data-testid` attributes to `ElegantContactForm`'s fields, submit button, and success/error containers, and rewrote the contact-form spec to select on `getByTestId(...)` instead of placeholder/text-based locators.
- Documented the `npm run test:e2e` script, its `NODE_DIR` requirement, and Radix Themes' `data-testid` prop forwarding in the README, AGENTS.md, and CLAUDE.md.

## Risk Assessment

✅ Low: The only change since the last round is the single-step fix that resolves NODE_DIR from `which npm` and appends it to GITHUB_ENV before the Playwright run step, directly and correctly addressing the previously flagged error; the workflow is workflow_dispatch-only so it cannot block PRs even if something were still wrong.

## Testing

Both contact-form.spec.ts tests pass against a real production build/server, and manual screenshot evidence (form filled, success state, error state) confirms the new data-testid attributes correctly target the visible desktop copy of the form and the UI behaves as intended; no code issues found, and the worktree was left clean.

- Evidence: Contact form filled with test data (desktop copy, via new data-testid selectors) (local file: <code>/tmp/no-mistakes-evidence/01KWJ9B1K3PD87K0RZZSNKS0J5/01-form-filled.png</code>)
- Evidence: Success state after mocked 200 response - contact-success-message visible (local file: <code>/tmp/no-mistakes-evidence/01KWJ9B1K3PD87K0RZZSNKS0J5/02-success-state.png</code>)
- Evidence: Error state after mocked 500 response - contact-error-message visible, form values retained (local file: <code>/tmp/no-mistakes-evidence/01KWJ9B1K3PD87K0RZZSNKS0J5/03-error-state.png</code>)
<details>
<summary>Evidence: Playwright test run output for e2e/contact-form.spec.ts</summary>

```text
Running 2 tests using 2 workers

✓ 2 [chromium] › e2e/contact-form.spec.ts:38:7 › contact form › error response surfaces the error state (522ms)
✓ 1 [chromium] › e2e/contact-form.spec.ts:11:7 › contact form › happy path shows the success state (526ms)

2 passed (1.0m)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.github/workflows/e2e.yml:13` - The new E2E workflow&#39;s job env block sets WP_DOMAIN/WP_JSON_API_URI/WP_POSTS_URI but never sets NODE_DIR. server.js calls cnad.config(process.env.NODE_DIR) unconditionally on startup, and per this same branch&#39;s own AGENTS.md note, cnad exits the process immediately when NODE_DIR is unset. Playwright&#39;s webServer.env merges with (rather than replaces) the spawner&#39;s process.env, but on a fresh GitHub Actions runner there&#39;s no NODE_DIR anywhere (not in the job env, not in a committed .env file - .gitignore blanket-ignores .env*). So `npm run test:e2e` in this workflow will always fail before the server binds a port, exactly reproducing the failure mode documented in this branch&#39;s AGENTS.md/CLAUDE.md. The workflow is workflow_dispatch-only so it won&#39;t block PRs, but as committed it can never succeed.

🔧 Fix: Set NODE_DIR in E2E workflow so cnad doesn&#39;t exit early
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm install (dependency setup) + npm approve-scripts esbuild sharp unrs-resolver (reverted afterward via git checkout)`
- `Fetched missing Chromium shared libs via apt-get download + dpkg-deb -x per CLAUDE.md notes (no sudo)`
- `NODE_DIR=$(dirname $(dirname $(which npm))) npx playwright test e2e/contact-form.spec.ts --reporter=list`
- `Manual Playwright script driving the production server (server.js, NODE_ENV=production) through the same data-testid selectors used in the spec, capturing screenshots of filled/success/error states`
- `git status before and after cleanup to confirm the worktree is clean (node_modules/.next left in place but are gitignored)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
