### PR TITLE
ci: remove hardcoded env values from verify-and-build job in ACA workflow

### DIFF
--- a/.github/workflows/deploy-azure-container-apps.yml
+++ b/.github/workflows/deploy-azure-container-apps.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ALLOWED_ORIGIN: "http://localhost:3000"
-      WP_DOMAIN: "example.com"
+      ALLOWED_ORIGIN: ${{ secrets.ALLOWED_ORIGIN }}
+      WP_DOMAIN: ${{ secrets.WP_DOMAIN }}
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
## Intent

Follow-up fix to PR #124 (Azure Container Apps migration groundwork). The captain reviewed the merged deploy-azure-container-apps.yml and does not want any hardcoded values in that workflow file, full stop - not even in the verify-and-build job, which existed only to make npm run build succeed (it doesn't deploy anything) and had hardcoded placeholder strings ALLOWED_ORIGIN="http://localhost:3000" and WP_DOMAIN="example.com". Changed these to reference the existing GitHub Environment secrets (secrets.ALLOWED_ORIGIN, secrets.WP_DOMAIN) that are already configured on this repo and already used by the deploy job in the same file and by deploy-to-cpanel.yml - matching that existing convention exactly, not introducing vars vs secrets as a new decision (that's explicitly left open by the captain for later). Confirmed no other hardcoded values exist elsewhere in the file (the deploy job already sources everything from vars.*/secrets.*). This is intentionally a small, surgical fix - the Terraform module, Dockerfile, and everything else from PR #124 are explicitly out of scope and were not touched. Verified locally: YAML parses, and npm run build succeeds with those two env vars set to placeholder values (the point of this fix is only what's committed to the workflow file, not making the manual workflow_dispatch runnable end-to-end since that needs real Azure secrets not yet configured).

## What Changed

- Replaced the hardcoded placeholder strings `ALLOWED_ORIGIN="http://localhost:3000"` and `WP_DOMAIN="example.com"` in the `verify-and-build` job of `deploy-azure-container-apps.yml` with references to `secrets.ALLOWED_ORIGIN` and `secrets.WP_DOMAIN`.
- Aligns this job with the existing secrets-based convention already used by the workflow's deploy job and by `deploy-to-cpanel.yml`, rather than introducing a new vars-vs-secrets convention.

## Risk Assessment

✅ Low: Two-line change replacing hardcoded placeholders with secrets already used elsewhere in the same file and in deploy-to-cpanel.yml; no behavioral, security, or structural risk.

## Testing

This is a minimal, workflow-file-only fix: the diff swaps two hardcoded strings for `${{ secrets.ALLOWED_ORIGIN }}` / `${{ secrets.WP_DOMAIN }}` in the verify-and-build job's env block, exactly mirroring the deploy job in the same file and deploy-to-cpanel.yml. I confirmed the YAML still parses, confirmed no other hardcoded values remain in the file, and reproduced the underlying npm run build with those two vars set to placeholder values (as the workflow would receive if the secrets held equivalent values) - the build succeeds and generates all routes; the WP fetch-failed log lines are expected in this sandbox with no reachable WordPress backend and don't affect the result. No CI run against real GitHub secrets was performed (not possible/needed here), consistent with the stated intent that this fix isn't meant to make the workflow_dispatch runnable end-to-end.

<details>
<summary>Evidence: npm run build output with ALLOWED_ORIGIN/WP_DOMAIN env vars set (mirrors the workflow&#39;s verify-and-build job)</summary>

```text
Build succeeds: generates all 12 routes (/, /blog, /experience, /projects, /api/contact, sitemap.xml, robots.txt, etc). The '[WP API] Error fetching ...: fetch failed' lines are expected since no WordPress backend is reachable in this sandbox; they don't affect build success.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `python3 yaml.safe_load() on .github/workflows/deploy-azure-container-apps.yml to confirm it still parses`
- `grep for quoted literal values in the workflow file to confirm no other hardcoded values remain (only hit is inside a code-comment example, not live config)`
- `diff review confirming the change is a 2-line, single-file edit scoped only to the verify-and-build job's env block`
- <code>`npm ci &amp;&amp; ALLOWED_ORIGIN=&#34;http://localhost:3000&#34; WP_DOMAIN=&#34;example.com&#34; npm run build` to reproduce what the workflow&#39;s verify-and-build step does when those secrets resolve to placeholder-like values</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
