### PR TITLE
ci: remove changelog-style comment from ACA workflow

### DIFF
--- a/.github/workflows/deploy-azure-container-apps.yml
+++ b/.github/workflows/deploy-azure-container-apps.yml
@@ -1,12 +1,5 @@
 name: Deploy to Azure Container Apps
 
-# Continuous deployment is live: the Azure infrastructure is provisioned and
-# a manual workflow_dispatch run has already succeeded end to end, so every
-# push to main now also deploys here. deploy-to-cpanel.yml remains the
-# separate, currently-still-live production deploy path until DNS is
-# explicitly cut over in a later phase - both workflows running on every
-# push to main is expected until then. workflow_dispatch is kept for manual
-# re-runs and rollback-redeploys.
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
## Intent

Remove a changelog-style comment block from .github/workflows/deploy-azure-container-apps.yml. The comment (added in PR #127, merged just before this task) sat above the 'on:' trigger block and narrated development-process history: that continuous deployment is now live, that a manual workflow_dispatch run already succeeded end to end, that deploy-to-cpanel.yml is still the separate live production path until DNS cutover, and that workflow_dispatch is kept for manual re-runs/rollback. The captain's standing preference is that code comments must not be used as a changelog or development-process narrative - that belongs in the PR description and rots as the codebase evolves. This is the second time this exact comment pattern appeared (a prior version described the pre-CD state and had the same problem), so the fix is to delete the whole comment block outright, not rewrite it again. The only change is removing those 7 comment lines; the on: block itself (push to main + workflow_dispatch) is untouched, since the two triggers coexisting is self-explanatory. AGENTS.md's 'Deployment' section (updated in the same PR #127) already documents this narrative durably outside the workflow file, so no comment needs to be added back and nothing was added to AGENTS.md for this trivial deletion. This is a single, deliberate deletion with no other changes to this file or elsewhere.

## What Changed

- Deleted a 7-line changelog-style comment block above the `on:` trigger in `.github/workflows/deploy-azure-container-apps.yml` that narrated deployment-process history (CD going live, the successful manual `workflow_dispatch` run, `deploy-to-cpanel.yml` remaining the live production path, and the rationale for keeping `workflow_dispatch`).
- No functional change: the `on:` trigger block (push to `main` plus `workflow_dispatch`) is untouched, and no other files are affected.
- This narrative is already captured durably in the project's `CLAUDE.md` Deployment section, so nothing needed to be added back.

## Risk Assessment

✅ Low: Purely a 7-line comment deletion in a CI workflow file with no change to triggers, jobs, or steps; nothing functional is affected.

## Testing

This is a pure comment-only deletion in a CI workflow YAML file with no runtime or UI surface, so no screenshot/product artifact applies; verification consisted of confirming via git diff that only the intended 7 comment lines were removed (0 insertions, no other files touched), and that the workflow YAML still parses correctly with an unchanged `on:` trigger block (push to main + workflow_dispatch) after the deletion. All checks passed with no findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 862a184..22d31b8 -- .github/workflows/deploy-azure-container-apps.yml` to confirm the exact deletion</code>
- <code>`git diff --stat 862a184..22d31b8` to confirm no other files/lines changed</code>
- <code>Parsed the workflow YAML with `python3 -c &#34;import yaml; yaml.safe_load(...)&#34;` to confirm it remains syntactically valid after the deletion</code>
- <code>Diffed the `on:` trigger block before vs after the change to confirm push-to-main + workflow_dispatch triggers are byte-identical and unaffected</code>
- <code>`git status --short` to confirm a clean working tree with no stray changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
