### PR TITLE
chore: remove changelog-style narrative from code comments

### DIFF
--- a/app/components/ExperienceCard.tsx
+++ b/app/components/ExperienceCard.tsx
@@ -77,7 +77,6 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
   const titleText = typeof title === "string" ? title : title.rendered;
   const galleryIds = gallery ? gallery.split(",").map((id) => id.trim()) : [];
 
-  // Parse gallery captions from JSON
   let galleryCaptions: Record<string, string> = {};
   if (galleryCaptionsJson) {
     try {
@@ -87,7 +86,6 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({
     }
   }
 
-  // Build gallery images for dialog
   const galleryImages = galleryIds
     .map((idStr) => {
       const mediaId = parseInt(idStr, 10);

--- a/app/components/PortfolioNav.tsx
+++ b/app/components/PortfolioNav.tsx
@@ -34,7 +34,6 @@ const PortfolioNav: React.FC<PortfolioNavProps> = ({
 
   useEffect(() => {
     setMounted(true);
-    // Read initial theme
     const saved = localStorage.getItem("theme") as "light" | "dark" | null;
     if (saved) {
       setTheme(saved);
@@ -45,7 +44,6 @@ const PortfolioNav: React.FC<PortfolioNavProps> = ({
       setTheme(prefersDark ? "dark" : "light");
     }
 
-    // Listen for theme changes
     const observer = new MutationObserver(() => {
       const isDark = document.documentElement.classList.contains("dark");
       setTheme(isDark ? "dark" : "light");

--- a/app/components/ProjectCard/ProjectCard.tsx
+++ b/app/components/ProjectCard/ProjectCard.tsx
@@ -16,7 +16,7 @@ export type BlogPostExcerpt = {
   modifiedGmt: string;
   slug: string;
   status: string;
-  link?: string; // url (deprecated - using slug now)
+  link?: string; // url
   titleRendered: string;
   featuredMedia?: string; // url
   categories?: string[];
@@ -271,7 +271,6 @@ const ProjectCard: React.FC<{
   const gallery = meta?._project_gallery;
   const galleryCaptionsJson = meta?._project_gallery_captions;
 
-  // Parse gallery captions from JSON
   let galleryCaptions: Record<string, string> = {};
   if (galleryCaptionsJson) {
     try {
@@ -281,10 +280,8 @@ const ProjectCard: React.FC<{
     }
   }
 
-  // Get gallery image IDs
   const galleryIds = gallery ? gallery.split(",").map((id) => id.trim()) : [];
 
-  // Build gallery images for dialog
   const galleryImages = galleryIds
     .map((idStr) => {
       const mediaId = parseInt(idStr, 10);

--- a/app/components/icons/CategoryIcons.tsx
+++ b/app/components/icons/CategoryIcons.tsx
@@ -55,7 +55,6 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({
 
 export default CategoryIcon;
 
-// Export individual icons for direct use
 export const AboutIcon = PersonIcon;
 export const CareerIcon = TimerIcon;
 export const SkillsIcon = StackIcon;

--- a/app/lib/theme-context.tsx
+++ b/app/lib/theme-context.tsx
@@ -17,7 +17,6 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     setMounted(true);
-    // Check for saved theme preference or system preference
     const saved = localStorage.getItem('theme') as Theme | null;
     if (saved) {
       setTheme(saved);

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -2,12 +2,8 @@
 # verification records - point the registrar's name servers at
 # dns_zone_name_servers (see outputs.tf) to complete the cutover.
 #
-# Gated behind enable_custom_domain (default false): the captain doesn't
-# currently have registrar access (domain_name is mid-transfer away from
-# cPanel hosting), so the first apply stands up only the core app infra,
-# reachable via the Container App's own default FQDN. This zone - and every
-# other domain-dependent resource in this file and frontdoor.tf - gets
-# created in a later apply once registrar/DNS delegation access is back.
+# TODO: apply with enable_custom_domain=true once registrar/DNS delegation
+# access for domain_name is available.
 resource "azurerm_dns_zone" "primary" {
   count               = var.enable_custom_domain ? 1 : 0
   name                = var.domain_name

--- a/terraform/frontdoor.tf
+++ b/terraform/frontdoor.tf
@@ -4,10 +4,8 @@
 # Front Door endpoint (see dns.tf's azurerm_dns_a_record.app), which a
 # literal CNAME at the apex cannot do. See README.md for the full rationale.
 #
-# Every resource here is gated behind enable_custom_domain (default false,
-# see variables.tf and dns.tf) - the first apply stands up only the core app
-# infra, reachable via the Container App's own default FQDN, since the
-# captain doesn't currently have registrar access for domain_name.
+# TODO: apply with enable_custom_domain=true once registrar/DNS delegation
+# access for domain_name is available (see variables.tf and dns.tf).
 resource "azurerm_cdn_frontdoor_profile" "app" {
   count               = var.enable_custom_domain ? 1 : 0
   name                = "${var.app_name}-fd"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -11,9 +11,5 @@ container_image = "shaganplaatjies.azurecr.io/shaganplaatjies:latest"
 
 wp_domain = "blog.shaganplaatjies.co.za"
 
-# Leave false for the first apply: it stands up the app reachable only via
-# the Container App's own default FQDN, with no DNS zone, apex records, or
-# Front Door resources - none of which need registrar access. Flip to true
-# for a later apply, once DNS delegation access for domain_name exists
-# again, to create the DNS zone/apex alias/Front Door custom domain.
+# TODO: flip to true once DNS delegation access for domain_name exists again.
 # enable_custom_domain = true

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -12,10 +12,7 @@ terraform {
     }
   }
 
-  # Intentionally no backend block. This phase ships local-state Terraform
-  # for review only - nothing here has been applied against a real Azure
-  # subscription. Configure a remote (azurerm storage account) backend once
-  # a subscription exists and the captain decides on a state storage account.
+  # TODO: configure a remote (azurerm storage account) backend.
 }
 
 provider "azurerm" {


### PR DESCRIPTION
## Intent

Standing captain preference: code comments should not read as a changelog or development-process narrative (no 'used to be X, now Y', 'as of PR #N', 'the captain decided to switch to X because...', or 'flip this once X happens' unless the condition is still genuinely pending, in which case it becomes a terse 'TODO: <what>' with no surrounding prose). This was triggered after a prior crewmate rewrote such a comment instead of deleting it. Swept the whole repo (excluding node_modules, lockfiles, generated output, and markdown docs like AGENTS.md/CLAUDE.md/README.md which intentionally serve as living process memory) file-by-file for comments matching this pattern, judging each individually rather than using a blind regex delete. Removed 9 comments that merely restated the following line/block, removed 1 past-decision narrative comment (a 'deprecated - using slug now' annotation), and collapsed 4 Terraform comments describing a still-pending conditional flip (registrar/DNS access, remote Terraform backend) down to bare 'TODO' comments, stripping the surrounding narrative prose while keeping the actionable fact. Comments explaining a genuinely non-obvious constraint, invariant, or workaround (Satori/Tailwind build quirks, Azure Front Door apex-CNAME DNS limitations, OIDC least-privilege rationale, Key Vault RBAC bootstrap ordering, etc.) were deliberately left untouched since removing them would lose real information, not just narrative rot. Per explicit instructions, .github/workflows/deploy-azure-container-apps.yml's 'on:' block header was left completely untouched since a separate, already in-flight task (PR #128, branch fm/workflow-comment-p2) owns that file. Verified with tsc --noEmit, next lint, and terraform fmt -check - all clean; this is a comment-only change with no behavior change.

## What Changed

- Removed comments in `app/components/ExperienceCard.tsx`, `PortfolioNav.tsx`, `ProjectCard.tsx`, `CategoryIcons.tsx`, and `app/lib/theme-context.tsx` that either restated the following line/block or narrated a past decision (e.g. a "deprecated - using slug now" annotation) instead of documenting a non-obvious constraint.
- Collapsed narrative comments in `terraform/dns.tf`, `terraform/frontdoor.tf`, `terraform/terraform.tfvars.example`, and `terraform/versions.tf` describing still-pending conditional flips (registrar/DNS access, remote Terraform backend) down to bare `TODO` comments, keeping the actionable fact and dropping the surrounding prose.
- No logic, structure, or behavior changed; this is a comment-only sweep.

## Risk Assessment

✅ Low: Comment-only diff (163 lines, no code logic touched); every removal either restates the following line or collapses stale/narrative prose into a bare TODO while preserving the actionable fact, matching the stated intent exactly, and the excluded workflow file was correctly left untouched.

## Testing

Confirmed via diff inspection that the change is purely comment removal (no code lines altered), then proved the app still builds and runs correctly by building and serving it for real and screenshotting the homepage in both light and dark mode (dark-mode toggle exercises the exact PortfolioNav/theme-context code whose comments were touched) - both rendered and functioned identically to expectations. The repo's existing live-WP smoke tests fail in this sandbox purely because the sandbox has no network route to the project's own WP domains (unrelated pre-existing infra limitation, not a regression from this change).

- Evidence: Homepage in light mode after the comment sweep (local file: <code>/tmp/no-mistakes-evidence/01KX1AA98PJ4BP7DG5T92Z19NS/homepage.png</code>)
- Evidence: Homepage in dark mode after clicking the theme toggle (exercises PortfolioNav.tsx/theme-context.tsx logic whose comments were removed) (local file: <code>/tmp/no-mistakes-evidence/01KX1AA98PJ4BP7DG5T92Z19NS/theme-toggled.png</code>)
- Evidence: Experience route hero section rendering correctly (local file: <code>/tmp/no-mistakes-evidence/01KX1AA98PJ4BP7DG5T92Z19NS/experience.png</code>)
- Outcome: ⚠️ 1 info across 1 run (9m18s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The 3 live-WP smoke tests in `e2e/smoke.spec.ts` (blog/projects/experience) fail in this sandbox because `staging.blog.shaganplaatjies.co.za` doesn&#39;t resolve here (sandbox network egress is allowlisted to npm/GitHub/etc., not the project&#39;s own WP domains). Confirmed via `getent hosts` that none of the project&#39;s real domains resolve, while npm/GitHub do. This is a pre-existing sandbox limitation unrelated to the comment-only diff being tested (comments cannot affect a fetch&#39;s DNS resolution), not something I can fix.
- `git diff 38e76ab..313f831 -- app/ terraform/ (confirmed only comment lines changed, no logic/structure touched)`
- `npm ci && next build (via npm run build) - compiled cleanly with the comment-only changes in ExperienceCard.tsx, PortfolioNav.tsx, ProjectCard.tsx, CategoryIcons.tsx, theme-context.tsx`
- `node server.js against the production build, manually exercised with Playwright: loaded /, /experience, /projects, /blog and captured screenshots`
- `Playwright-driven theme toggle click on the homepage (exercises the exact PortfolioNav.tsx/theme-context.tsx code whose surrounding comments were removed) - confirmed light/dark mode still switches correctly`
- `npx playwright test e2e/smoke.spec.ts (existing live-WP smoke suite) - all 3 tests fail due to sandbox DNS/network restrictions blocking the live WP staging backend, unrelated to this diff`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
